### PR TITLE
Patch 1.1.3 - Disable istio for tdx feature

### DIFF
--- a/docs/tdx.md
+++ b/docs/tdx.md
@@ -97,12 +97,12 @@ Follow the steps below to deploy ChatQnA:
    docker login your_container_registry
    ```
 
-4. Push the images to your container registry and deploy ChatQnA by adding `--features tdx` parameter and leaving all other parameters without changes (note, that only `*xeon*` pipelines are supported with Intel TDX):
+4. Push the images to your container registry and deploy ChatQnA by adding `--no-mesh --features tdx` parameter and leaving all other parameters without changes (note, that only `*xeon*` pipelines are supported with Intel TDX):
 
    ```bash
    ./update_images.sh --build --push --registry "${REGISTRY}" --tag "${TAG}"
    ./set_values.sh -g "${HUGGINGFACEHUB_API_TOKEN}" -r "${REGISTRY}" -t "${TAG}"
-   ./install_chatqna.sh --deploy "${PIPELINE}" --registry "${REGISTRY}" --tag "${TAG}" --features tdx
+   ./install_chatqna.sh --deploy "${PIPELINE}" --registry "${REGISTRY}" --tag "${TAG}" --no-mesh --features tdx
    ```
 
 


### PR DESCRIPTION
## Description

Istio is not working with kata-qemu-tdx runtime class, so we need to disable it until the solution is implemented.

## Issues

 `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [x] Others (enhancement, documentation, validation, etc.)

## Tests

Manual tests
