### PR TITLE
Update environment for unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -44,16 +44,6 @@ jobs:
           "$AGENT_TOOLSDIRECTORY"
         df -h /
 
-#    - name: Install Python 3.11 system-wide
-#      run: |
-#        sudo apt-get update
-#        sudo apt-get install -y python3.11 python3.11-venv python3.11-dev
-#
-#    - name: Set Python 3.11 as system default
-#      run: |
-#        sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
-#        sudo update-alternatives --set python3 /usr/bin/python3.11
-
     - name: Install test prerequisites
       run: sudo apt-get update && sudo apt-get -y install libgl1 tox
 


### PR DESCRIPTION
Fix running environment to ensure Python version for unit tests is at least 3.11. For ubuntu 24 it's 3.12 so it's ok.