### PR TITLE
Change IAC deployment to point to 1.5.0 tag

### DIFF
--- a/deployment/terraform/scripts/run_install.sh
+++ b/deployment/terraform/scripts/run_install.sh
@@ -30,7 +30,7 @@ INSTALL_DEBUG_TOOLS=false      # Install debug tools (k9s, etc.)
 # Repository configuration
 REPO_URL="https://github.com/opea-project/Enterprise-RAG.git"
 REPO_DIR="/tmp/Enterprise-RAG"
-GIT_BRANCH="main"
+GIT_BRANCH="release-1.5.0"
 DEPLOYMENT_DIR="${REPO_DIR}/deployment"
 INVENTORY_DIR="${DEPLOYMENT_DIR}/inventory"
 CLUSTER_CONFIG_DIR="${INVENTORY_DIR}/cluster"


### PR DESCRIPTION
## Description

run_install.sh was pointing to main. For backward compatibility of IAC versions should point to specific tag per release.

## Issues

Fixes #(github issue). If there is no such issue, please mark it as `n/a`.

## Type of change

List the type of change like below. Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds new functionality)
- [ ] Breaking change (fix or feature that would break existing design and interface)
- [ ] Others (enhancement, documentation, validation, etc.)

## Tests

Describe the tests that you ran to verify your changes.
